### PR TITLE
Count number of atoms in molecule

### DIFF
--- a/sendoff/sdblock.py
+++ b/sendoff/sdblock.py
@@ -4,11 +4,129 @@ from __future__ import annotations
 import os
 from collections import deque
 from dataclasses import dataclass
+from enum import Enum
 from io import TextIOWrapper
 from itertools import chain, groupby
 from typing import Iterable, Iterator, Tuple, Union
 
 Pathy = Union[str, bytes, os.PathLike]
+
+
+class CTableFormat(Enum):
+    """The format a CTAB comes in, either V2000 or V3000."""
+
+    V2000 = "V2000"
+    V3000 = "V3000"
+
+
+class CTable:
+    """Handle a Connection table (CTAB) from a single molecule block.
+
+    Parsed in based on https://en.wikipedia.org/wiki/Chemical_table_file.
+    As part of parsing, record the title, the source line, the comment line,
+    and the counts line. The rest of the lines are kept but not parsed.
+    The counts line is parsed to infer the format and the number of atoms.
+    Note, the number of atoms in the counts line might not actually
+    be the number of lines of atoms.
+    """
+
+    lines: deque[str]
+    title: str
+    source: str
+    comment: str
+    counts: str
+    format: CTableFormat
+    num_atoms: int
+
+    def __init__(self, lines: Iterable[str]) -> None:
+        """Parse in lines representing the CTAB, including the title line.
+
+        Args:
+            lines: an Iterable of str that comprises the CTAB
+                The title line is parsed in by the SDBlock, and should
+                be supplied as the first in lines.
+
+        """
+        self.lines = deque(lines)
+        iterlines = iter(self.lines)
+        self.title = next(iterlines).strip()
+        self.source = next(iterlines)
+        self.comment = next(iterlines)
+        self.counts = next(iterlines).strip()
+        self.format = self.parse_format(self.counts)
+        if self.format is CTableFormat.V3000:
+            next(iterlines)  # CTAB BEGIN line
+            self.counts = next(iterlines).strip()
+            self.num_atoms = self.parse_v3000_counts(self.counts)
+        else:
+            self.num_atoms = self.parse_v2000_counts(self.counts)
+        return
+
+    @staticmethod
+    def parse_format(line: str) -> CTableFormat:
+        """Parse a v2000 counts line according to get the format.
+
+        The line could be from a V3000 block, where it is used for
+        compatibility purposes. In that case, the actual
+        counts line comes later.
+
+        Can raise KeyError: when the CTableFormat could not be parsed
+                from the counts line
+
+        Args:
+            line: a counts line parsed in as part of the CTAB block.
+                Expected to be whitespace stripped.
+
+        Returns:
+            A CTAB format, based on the end of the counts line
+        """
+        sline = line.split()
+        ctformat = CTableFormat[sline[-1]]
+        return ctformat
+
+    @staticmethod
+    def parse_v2000_counts(line: str) -> int:
+        """Parse a v2000 counts line according to get the number of atoms.
+
+        The line could be from a V3000 block, where it is used for
+        compatibility purposes. In that case, the actual
+        counts line comes later, and this is not the right function to call.
+
+        Note, V2000 maxes out at 999 atoms because the counts line
+        can only handle 3 characters for the number of atoms.
+
+        Can raise ValueError: when the number could not be parsed
+                from the counts line
+
+        Args:
+            line: a counts line parsed in as part of the CTAB block.
+                Expected to be whitespace stripped.
+
+        Returns:
+            The number of atoms indicated by the counts line.
+                Not the actual number of atom lines further down.
+        """
+        num_atoms = int(line[:3])
+        return num_atoms
+
+    @staticmethod
+    def parse_v3000_counts(line: str) -> int:
+        """Parse a v3000 counts line according to get the number of atoms.
+
+        Can raise ValueError: when the number could not be parsed
+                from the counts line
+
+        Args:
+            line: a counts line parsed in as part of the CTAB block.
+                Expected to be whitespace stripped.
+
+        Returns:
+            The number of atoms indicated by the counts line.
+                Not the actual number of atom lines further down.
+        """
+        sline = line.split()
+        num_atoms = int(sline[3])
+        return num_atoms
 
 
 @dataclass
@@ -131,6 +249,19 @@ class SDBlock:
         self.metadata.append(f"> <{record_name}>\n")
         self.metadata.append(value + "\n")
         self.metadata.append("\n")
+
+    def num_atoms(self) -> int:
+        """Get number of atoms as indicated in the MDL block.
+
+        The mdl lines are parsed in to generate a CTable.
+        Based on the format parsed, the number of atoms is parsed
+        from the counts line. Note, this is not the number of atom lines.
+
+        Returns:
+            The number of atoms, parsed in from the counts line.
+        """
+        ctable = CTable(chain([self.title], self.mdl))
+        return ctable.num_atoms
 
 
 def parse_sdf(sdfpath: Pathy) -> Iterator[SDBlock]:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,6 +62,89 @@ def double_mol_sdf(request: FixtureRequest, tmp_path: Path) -> Path:
 
 
 @pytest.fixture(params=["rdkitV2000", "rdkitV3000"])
+def single_0_atoms_mol_sdf(request: FixtureRequest, tmp_path: Path) -> Path:
+    """Write a single molecule with 0 atoms and no metadata to an sdf.
+
+    This relies on the fact that RDKit does not write hydrogens by default.
+
+    Args:
+        request: pytest fixture configuration handling param passing
+        tmp_path: pytest fixture for writing files to a temp directory
+
+    Returns:
+        Path to the sdf
+    """
+    mol = Chem.MolFromSmiles("C" * 0)
+    outpath = tmp_path / "input.sdf"
+    with Chem.SDWriter(str(outpath)) as sdw:
+        sdw.SetForceV3000(request.param == "rdkitV3000")
+        sdw.write(mol)
+    return outpath
+
+
+@pytest.fixture(params=["rdkitV2000", "rdkitV3000"])
+def single_star_atom_mol_sdf(request: FixtureRequest, tmp_path: Path) -> Path:
+    """Write a single molecule with a single star atom and no metadata to an sdf.
+
+    This relies on the fact that RDKit does not write hydrogens by default.
+
+    Args:
+        request: pytest fixture configuration handling param passing
+        tmp_path: pytest fixture for writing files to a temp directory
+
+    Returns:
+        Path to the sdf
+    """
+    mol = Chem.MolFromSmiles("*")
+    outpath = tmp_path / "input.sdf"
+    with Chem.SDWriter(str(outpath)) as sdw:
+        sdw.SetForceV3000(request.param == "rdkitV3000")
+        sdw.write(mol)
+    return outpath
+
+
+@pytest.fixture(params=["rdkitV2000", "rdkitV3000"])
+def single_999_atoms_mol_sdf(request: FixtureRequest, tmp_path: Path) -> Path:
+    """Write a single molecule with 999 atoms and no metadata to an sdf.
+
+    This relies on the fact that RDKit does not write hydrogens by default.
+
+    Args:
+        request: pytest fixture configuration handling param passing
+        tmp_path: pytest fixture for writing files to a temp directory
+
+    Returns:
+        Path to the sdf
+    """
+    mol = Chem.MolFromSmiles("C" * 999)
+    outpath = tmp_path / "input.sdf"
+    with Chem.SDWriter(str(outpath)) as sdw:
+        sdw.SetForceV3000(request.param == "rdkitV3000")
+        sdw.write(mol)
+    return outpath
+
+
+@pytest.fixture
+def single_1001_atoms_mol_sdf(tmp_path: Path) -> Path:
+    """Write a single molecule with 1001 atoms and no metadata to an sdf.
+
+    This relies on the fact that RDKit does not write hydrogens by default,
+    and that RDKit falls back to V3000 for molecules of more than 999 atoms.
+
+    Args:
+        tmp_path: pytest fixture for writing files to a temp directory
+
+    Returns:
+        Path to the sdf
+    """
+    mol = Chem.MolFromSmiles("C" * 1001)
+    outpath = tmp_path / "input.sdf"
+    with Chem.SDWriter(str(outpath)) as sdw:
+        sdw.write(mol)
+    return outpath
+
+
+@pytest.fixture(params=["rdkitV2000", "rdkitV3000"])
 def single_titled_mol_sdf(request: FixtureRequest, tmp_path: Path) -> Path:
     """Write a single molecule with only title metadata to an sdf.
 

--- a/tests/test_rdkit.py
+++ b/tests/test_rdkit.py
@@ -132,3 +132,43 @@ def test_multiline_record_name_mol_read(
     """
     mol = next(Chem.SDMolSupplier(str(single_multiline_record_name_mol_sdf)))
     assert not mol.HasProp("Rec\nord")
+
+
+def test_0_atoms_mol_num_atoms(single_0_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 0 atoms written parses as 0 atoms.
+
+    Args:
+        single_0_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol = next(Chem.SDMolSupplier(str(single_0_atoms_mol_sdf)))
+    assert mol.GetNumAtoms() == 0
+
+
+def test_star_atom_mol_num_atoms(single_star_atom_mol_sdf: Pathy) -> None:
+    """An sdf block with a single star atom written parses as 1 atom.
+
+    Args:
+        single_star_atom_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol = next(Chem.SDMolSupplier(str(single_star_atom_mol_sdf)))
+    assert mol.GetNumAtoms() == 1
+
+
+def test_999_atoms_mol_num_atoms(single_999_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 999 atoms written parses as 999 atoms.
+
+    Args:
+        single_999_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol = next(Chem.SDMolSupplier(str(single_999_atoms_mol_sdf)))
+    assert mol.GetNumAtoms() == 999
+
+
+def test_1001_atoms_mol_num_atoms(single_1001_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 1001 atoms written parses as 1001 atoms.
+
+    Args:
+        single_1001_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol = next(Chem.SDMolSupplier(str(single_1001_atoms_mol_sdf)))
+    assert mol.GetNumAtoms() == 1001

--- a/tests/test_sendoff.py
+++ b/tests/test_sendoff.py
@@ -176,3 +176,43 @@ def test_single_mol_newline_write_splitlines_no_trailing(single_mol_sdf: Pathy) 
     assert len(buffer.getvalue().splitlines()) < len(
         open(single_mol_sdf).read().splitlines()
     )
+
+
+def test_0_atoms_mol_num_atoms(single_0_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 0 atoms written parses as 0 atoms.
+
+    Args:
+        single_0_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol: SDBlock = next(parse_sdf(single_0_atoms_mol_sdf))
+    assert mol.num_atoms() == 0
+
+
+def test_star_atom_mol_num_atoms(single_star_atom_mol_sdf: Pathy) -> None:
+    """An sdf block with a single star atom written parses as 1 atom.
+
+    Args:
+        single_star_atom_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol: SDBlock = next(parse_sdf(single_star_atom_mol_sdf))
+    assert mol.num_atoms() == 1
+
+
+def test_999_atoms_mol_num_atoms(single_999_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 999 atoms written parses as 999 atoms.
+
+    Args:
+        single_999_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol: SDBlock = next(parse_sdf(single_999_atoms_mol_sdf))
+    assert mol.num_atoms() == 999
+
+
+def test_1001_atoms_mol_num_atoms(single_1001_atoms_mol_sdf: Pathy) -> None:
+    """An sdf block with 1001 atoms written parses as 1001 atoms.
+
+    Args:
+        single_1001_atoms_mol_sdf: pytest fixture of a Path to the sdf
+    """
+    mol: SDBlock = next(parse_sdf(single_1001_atoms_mol_sdf))
+    assert mol.num_atoms() == 1001


### PR DESCRIPTION
Provided by a tiny CTAB parsing class.
Test on 0, 1-star, 999, and 1001 atoms.
Deal with both V2000 and V3000 formats.